### PR TITLE
Wip 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ def generate_data():
 # Training procedure
 for epoch in range(100):
     for step, (x, y) in enumerate(generate_data()):
-        # Setting the natural waveform to estimate the best initial phase
-        model.source_module.sine_generator.natural_waveforms = y
         # Make a predicted waveform
-        y_pred = model(x).squeeze(-1)
+        # passing the natural waveform (y) to estimate the best initial phase
+        y_pred = model(x, y)
         # Compute loss
         loss = criterion(y_pred, y)
         # Update weight
@@ -81,14 +80,14 @@ Generating waveforms is done by giving a batch of sequences of fundamental frequ
 ```python
 # Importing, defining some constants, loading models, prepare F0 and context vectors...
 # x: (F0, context_vectors) in the previous subsection
-y_pred = model(x).squeeze(-1).detach().numpy().reshape(batch_size*waveform_length)
+y_pred = model(x).detach().numpy().reshape(batch_size*waveform_length)
 librosa.output.write_wav('predicted_waveform.wav', y_pred, sr=sampling_rate)
 ```
 
 ### TODO
 
 * documentation
-* make it a library (if it is combinient)
+* make it a library (if it is convenient)
 
 [^1]: https://nii-yamagishilab.github.io/samples-nsf/
 [^2]: https://github.com/nii-yamagishilab/project-CURRENNT-scripts

--- a/layers.py
+++ b/layers.py
@@ -1,7 +1,7 @@
 import torch
 from math import pi
 
-# input shape: NxBx1
+# input shape: NxB
 # output shape: NxTx(1+harmonics)
 class SineGenerator(torch.nn.Module):
     def __init__(self, waveform_length):
@@ -17,7 +17,7 @@ class SineGenerator(torch.nn.Module):
     def forward(self, x):
         # interpolate x (from NxBx1 to NxTx1)
         f = torch.nn.functional.interpolate(
-            x.transpose(1, 2), self.waveform_length
+            x.unsqueeze(-1).transpose(1, 2), self.waveform_length
         ).transpose(1, 2)
         h = torch.arange(1, self.harmonics + 2).unsqueeze(0).unsqueeze(0)
         n = torch.normal(

--- a/model.py
+++ b/model.py
@@ -5,7 +5,7 @@ from modules import SourceModule
 from modules import NeuralFilterModule
 
 # input: NxBxn_features
-# output: NxTx1
+# output: NxT
 class NSFModel(torch.nn.Module):
     def __init__(self, input_size, waveform_length):
         super(NSFModel, self).__init__()
@@ -19,13 +19,13 @@ class NSFModel(torch.nn.Module):
         )
 
     def forward(self, x):
-        F0 = x[:, :, 0].unsqueeze(-1)
+        F0 = x[:, :, 0]
         out_condition = self.condition_module(x)
         out_condition = torch.nn.functional.interpolate(
             out_condition.transpose(1, 2), self.waveform_length
         ).transpose(1, 2)
         out_source = self.source_module(F0)
-        out_filter = out_source.unsqueeze(-1) # TODO: make out_source 3-dim tensor
+        out_filter = out_source
         for m in self.neural_filter_modules:
             out_filter = m(out_filter, out_condition)
         return out_filter

--- a/model.py
+++ b/model.py
@@ -18,13 +18,13 @@ class NSFModel(torch.nn.Module):
             for _ in range(5)
         )
 
-    def forward(self, x):
+    def forward(self, x, y=None):
         F0 = x[:, :, 0]
         out_condition = self.condition_module(x)
         out_condition = torch.nn.functional.interpolate(
             out_condition.transpose(1, 2), self.waveform_length
         ).transpose(1, 2)
-        out_source = self.source_module(F0)
+        out_source = self.source_module(F0, y)
         out_filter = out_source
         for m in self.neural_filter_modules:
             out_filter = m(out_filter, out_condition)

--- a/modules.py
+++ b/modules.py
@@ -25,8 +25,8 @@ class ConditionModule(torch.nn.Module):
         x = torch.tanh(self.cnn(x.permute(0, 2, 1)).permute(0, 2, 1))
         return torch.cat((F0, x), dim=-1)
 
-# input: NxBx1
-# output: NxTx1
+# input: NxB
+# output: NxT
 class SourceModule(torch.nn.Module):
     def __init__(self, waveform_length):
         super(SourceModule, self).__init__()
@@ -90,7 +90,7 @@ class NeuralFilterModule(torch.nn.Module):
         # x: signal tensor from previous module
         # c: context tensor
         x_in = x
-        x = torch.tanh(self.causal_linear(x))
+        x = torch.tanh(self.causal_linear(x.unsqueeze(-1)))
         outputs_from_blocks = []
         ysum = 0
         for blk in self.dilute_blocks:
@@ -107,4 +107,4 @@ class NeuralFilterModule(torch.nn.Module):
                 self.postoutput_linear2(x).transpose(1, 2)
             ).transpose(1, 2)
         )
-        return x_in * torch.exp(x[:, :, 1].unsqueeze(-1)) + x[:, :, 0].unsqueeze(-1)
+        return x_in * torch.exp(x[:, :, 1]) + x[:, :, 0]

--- a/modules.py
+++ b/modules.py
@@ -32,8 +32,8 @@ class SourceModule(torch.nn.Module):
         super(SourceModule, self).__init__()
         self.sine_generator = SineGenerator(waveform_length)
         self.linear = torch.nn.Linear(8, 1)
-    def forward(self, x):
-        x = self.sine_generator(x)
+    def forward(self, x, y=None):
+        x = self.sine_generator(x, y)
         x = torch.tanh(self.linear(x))
         return torch.squeeze(x, -1)
 

--- a/test_generate_fake_data.py
+++ b/test_generate_fake_data.py
@@ -2,6 +2,7 @@
 
 import os
 import librosa
+import random
 import torch
 import numpy as np
 
@@ -38,7 +39,9 @@ def generate_data():
                 F0_dict[current_label] = np.array(F0_dict[current_label])
 
     F0_segments = []
-    for utt_label in sorted(F0_dict.keys()):
+    keys = list(F0_dict.keys())
+    random.shuffle(keys)
+    for utt_label in sorted(keys):
         F0 = F0_dict[utt_label]
         # align with the segment
         n_segments = int(ceil(F0.size / context_length))

--- a/test_generate_fake_data.py
+++ b/test_generate_fake_data.py
@@ -71,7 +71,7 @@ def main():
     model.load_state_dict(torch.load(statedict_path))
 
     x = next(generate_data())
-    y_pred = model(x).squeeze(-1).detach().numpy().reshape(batch_size*waveform_length)
+    y_pred = model(x).detach().numpy().reshape(batch_size*waveform_length)
     librosa.output.write_wav('arai_fake.wav', y_pred, sr=sampling_rate)
 
 if __name__ == '__main__':

--- a/test_sine_generator.py
+++ b/test_sine_generator.py
@@ -8,10 +8,10 @@ import librosa.display
 from layers import SineGenerator
 
 def main():
-    # unsqueeze to make 1x16x1 tensor
+    # unsqueeze to make 1x16 tensor
     x = torch.cat(
         (torch.zeros(6), 220 * torch.ones(5), 440 * torch.ones(5))
-    ).unsqueeze(-1).unsqueeze(0)
+    ).unsqueeze(0)
     siggen = SineGenerator(160000)
     y = siggen(x)
 

--- a/test_train.py
+++ b/test_train.py
@@ -13,7 +13,7 @@ def main():
     output_dim = 1
 
     x = torch.randn(batch_size, context_length, input_dim)
-    y = torch.randn(batch_size, waveform_length, output_dim)
+    y = torch.randn(batch_size, waveform_length)
 
     model = NSFModel(input_dim, waveform_length)
     Ls = spectral_amplitude_distance(512, 320, 80)
@@ -22,13 +22,13 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
 
     for t in range(101):
-        # TODO: match dimension
-        model.source_module.sine_generator.natural_waveforms = y.squeeze(-1)
+        # TODO: mark deprecated
+        model.source_module.sine_generator.natural_waveforms = y
         y_pred = model(x)
 
         # Compute and print loss
         # TODO: match dimension
-        loss = criterion(y_pred.squeeze(-1), y.squeeze(-1))
+        loss = criterion(y_pred, y)
         if t % 10 == 0:
             print(t, loss.item())
 

--- a/test_train.py
+++ b/test_train.py
@@ -22,12 +22,9 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
 
     for t in range(101):
-        # TODO: mark deprecated
-        model.source_module.sine_generator.natural_waveforms = y
-        y_pred = model(x)
+        y_pred = model(x, y) # give y to estimate the initial phase
 
         # Compute and print loss
-        # TODO: match dimension
         loss = criterion(y_pred, y)
         if t % 10 == 0:
             print(t, loss.item())

--- a/test_train_real_data.py
+++ b/test_train_real_data.py
@@ -116,10 +116,9 @@ def main():
         sum_loss = 0
         last_output_len = 0
         for step, (x, y) in enumerate(generate_data()):
-            # TODO: match dimension
-            y = y.squeeze(-1)
+            # TODO: mark deprecated
             model.source_module.sine_generator.natural_waveforms = y
-            y_pred = model(x).squeeze(-1)
+            y_pred = model(x)
 
             # Compute loss
             loss = criterion(y_pred, y)

--- a/test_train_real_data.py
+++ b/test_train_real_data.py
@@ -116,9 +116,7 @@ def main():
         sum_loss = 0
         last_output_len = 0
         for step, (x, y) in enumerate(generate_data()):
-            # TODO: mark deprecated
-            model.source_module.sine_generator.natural_waveforms = y
-            y_pred = model(x)
+            y_pred = model(x, y) # give y to estimate the initial phase
 
             # Compute loss
             loss = criterion(y_pred, y)

--- a/test_train_sourcemodule.py
+++ b/test_train_sourcemodule.py
@@ -22,8 +22,7 @@ def main():
     criterion = lambda y_pred, y: Ls(y_pred, y) + Lp(y_pred, y)
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
     for t in range(501):
-        model.sine_generator.natural_waveforms = y
-        y_pred = model(x)
+        y_pred = model(x, y)
 
         # Compute and print loss
         loss = criterion(y_pred, y)

--- a/test_train_sourcemodule.py
+++ b/test_train_sourcemodule.py
@@ -10,9 +10,9 @@ from modules import SourceModule
 from losses import spectral_amplitude_distance, phase_distance
 
 def main():
-    # unsqueeze to make 1x16x1 tensor
+    # unsqueeze to make 1x16 tensor
     waveform_length = 32000
-    x = torch.cat((440 * torch.ones(8000),)).unsqueeze(-1).unsqueeze(0)
+    x = torch.cat((440 * torch.ones(8000),)).unsqueeze(0)
     coeff, bias = torch.randn(8), torch.randn(1)
     y = torch.sum(coeff * SineGenerator(waveform_length)(x), -1) + bias
 


### PR DESCRIPTION
This closes #3.

* updated the output shapes of the `NSFModel` and the `SourceModule`
  - it was `(batch_size, waveform_length, 1)`
  - now `(batch_size, waveform_length)`
* natural waveforms `y` can be passed as `model.forward(x, y)`
  - now, passing natural waveforms to `model.source_module.sine_generator.natural_waveforms` is deprecated